### PR TITLE
Feature/cpp conditions in templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,4 +24,8 @@ if(CATKIN_ENABLE_TESTING)
     test/acceptanceTests.py
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
   )
+  catkin_add_nosetests(
+    test/unitTests.py
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/test
+  )
 endif()

--- a/src/eclipsify
+++ b/src/eclipsify
@@ -14,7 +14,6 @@ except:
     print("or use the eclipsify-gen-project cli tool.")
 
 import os
-import sys
 from eclipsify_lib.tools import colored
 from eclipsify_lib.eclipsify_gen_project import main, addCommonArguments
 

--- a/src/eclipsify
+++ b/src/eclipsify
@@ -42,7 +42,7 @@ addCommonArguments(parser)
 outputInSourceOutputDir = '{src}'
 
 parser.add_argument('-w', dest='eclipse_workspace', help='The path to the eclipse workspace that this package should be added to.')
-parser.add_argument('-s', dest='outputInSource', action='count', default=False, help='Will enforce in source writing of the project files. Equivalent to "-O \'%s\'". Any "-O" will be ignored!' % outputInSourceOutputDir)
+parser.add_argument('-s', dest='outputInSource', action='count', default=False, help='Will enforce in source writing of the project files. Equivalent to "-O \'%s\' -D IN_SOURCE=1". An additionally provided "-O" will take precedence.' % outputInSourceOutputDir)
 parser.add_argument('-O', dest='projectOutputDir', default="{devel}/share/{package}/eclipse", help='The path to the folder in which the eclipse project files should be created. The substrings {devel}, {package} and {src} will be replaced appropriately.')
 parser.add_argument('-W,--catkin-ws', dest='catkin_workspace', help='The path to the catkin workspace that this package should be. It must point to the workspace\'s devel space! Default is to use the current catkin workspace layers ("sourced").')
 
@@ -145,7 +145,9 @@ print
 
 if options.outputInSource :
     if options.verbose : print(colored("In source output is active. Overwriting output directory with '%s'." % outputInSourceOutputDir, 'yellow'));
-    options.projectOutputDir = outputInSourceOutputDir
+    if not options.projectOutputDir:
+        options.projectOutputDir = outputInSourceOutputDir
+    options.define.append('IN_SOURCE=1');
 
 eclipse_project_output_dir = options.projectOutputDir.format(devel = workspace.getDevelSpace(), package = package, src = src).replace('/', os.path.sep)
 

--- a/src/eclipsify_lib/eclipsify_gen_project.py
+++ b/src/eclipsify_lib/eclipsify_gen_project.py
@@ -9,6 +9,7 @@ def addCommonArguments(parser):
     parser.add_argument('-v', '--verbose', action='count', help="Verbosity level.", default=0)
     parser.add_argument("-f", "--force", action='count', help="Force overwriting existing files.", default=False)
     parser.add_argument('-T', '--templates', help="Templates search path prefix; colon separated.", default="")
+    parser.add_argument('-D', '--define', action='append', metavar="DEFINE[=VALUE]", help="Add cpp (c pre-processor) definitions.", default=[])
     parser.add_argument("--platform", help="Platform (defaults to sys.platform).", default=sys.platform)
     parser.add_argument("package", nargs=1, help="The name of the catkin package to be eclipsified.")
 
@@ -30,8 +31,16 @@ def main(options = None):
     platform = options.platform
     outputDir = options.outDir[0]
     package = options.package[0]
-    
+
+    cppMacroDict = dict()
     print("eclipsify package %s for platform %s" % (package, platform))
+    if len(options.define) :
+        print("\tactive cpp macros / defines :");
+        for opt in options.define:
+            print("\t\t" + opt);
+            parts = opt.split('=', 2);
+            cppMacroDict[parts[0]] =  parts[1] if len(parts) > 1 else '1'
+
     print("----------")
 
     libDir = os.path.dirname(__file__);
@@ -48,7 +57,7 @@ def main(options = None):
         options.templates = options.templates[1:]
     templateSearchPaths = options.templates.split(':')
     if extendWithDefaultTemplatePaths:
-      templateSearchPaths.extend([userPlatformTemplatesDir, userTemplatesDir, platformTemplateDir, templatesDir]);
+        templateSearchPaths.extend([userPlatformTemplatesDir, userTemplatesDir, platformTemplateDir, templatesDir]);
 
     # get rid of empty template search paths
     templateSearchPaths = [ p for p in templateSearchPaths if (p) ]
@@ -56,7 +65,7 @@ def main(options = None):
     tools.addModuleSaearchDirsAndCleanFromDanglingPycFiles(templateSearchPaths);
     import projectFiles
     
-    projectFilesGenerator = generator.ProjectFilesGenerator(options.verbose, package, options.srcDir[0], options.buildDir[0])
+    projectFilesGenerator = generator.ProjectFilesGenerator(options.verbose, package, options.srcDir[0], options.buildDir[0], cppMacros = cppMacroDict)
     
     import precondition
 

--- a/src/eclipsify_lib/templates/darwin/.cproject
+++ b/src/eclipsify_lib/templates/darwin/.cproject
@@ -117,4 +117,3 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
-

--- a/src/eclipsify_lib/templates/linux2/.cproject
+++ b/src/eclipsify_lib/templates/linux2/.cproject
@@ -70,4 +70,3 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
-

--- a/src/eclipsify_lib/templates/linux2/.project
+++ b/src/eclipsify_lib/templates/linux2/.project
@@ -24,6 +24,7 @@
 		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
 		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
 	</natures>
+#ifndef IN_SOURCE
 	<linkedResources>
 		<link>
 			<name>{name}_src</name>
@@ -31,4 +32,5 @@
 			<location>{srcDir}</location>
 		</link>
 	</linkedResources>
+#endif
 </projectDescription>

--- a/test/acceptanceTests.py
+++ b/test/acceptanceTests.py
@@ -10,12 +10,13 @@ class EclipsifyAcceptance(unittest.TestCase):
         unittest.TestCase.__init__(self, *args, **kwargs)
         os.environ['ECLIPSIFY_USE_RELATIVE_LOCATIONS_FOR_TESTING'] = "1"
 
-    def _testGeneratorGeneratesSame(self, platform, projects = ['test_project_1'], testWorkspace = 'testWs/devel'):
+    def _testGeneratorGeneratesSame(self, platform, inSource = False, projects = ['test_project_1'], testWorkspace = 'testWs/devel'):
         for project in projects:
-            outDir = 'expected/%s/%s/%s' % (testWorkspace, platform, project)
+            outDir = 'expected/%s/%s/%s' % (testWorkspace if not inSource else os.path.join(os.path.dirname(testWorkspace), "src"), platform, project)
             subprocess.call(['rm', '-rf', outDir])
             subprocess.call([sys.executable, 
                              '../src/eclipsify', '-v', 
+                             '-s' if inSource else '-v',
                              '-W', testWorkspace, 
                              '-O', outDir, 
                              '--platform', platform, 
@@ -31,8 +32,12 @@ class EclipsifyAcceptance(unittest.TestCase):
             self.assertEqual(c, 0, "There should be no difference between HEAD and the expected output! Either fix the code or commit changed expected output.")
     def testLinux(self):
         self._testGeneratorGeneratesSame('linux2')
+    def testLinuxInSource(self):
+        self._testGeneratorGeneratesSame('linux2', True)
     def testDarwin(self):
         self._testGeneratorGeneratesSame('darwin')
+    def testDarwinInSource(self):
+        self._testGeneratorGeneratesSame('darwin', True)
 if __name__ == '__main__':
     import rostest
     rostest.rosrun('eclipsify', 'acceptance', EclipsifyAcceptance)

--- a/test/expected/testWs/devel/darwin/test_project_1/.cproject
+++ b/test/expected/testWs/devel/darwin/test_project_1/.cproject
@@ -118,4 +118,3 @@
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
 
-

--- a/test/expected/testWs/devel/linux2/test_project_1/.cproject
+++ b/test/expected/testWs/devel/linux2/test_project_1/.cproject
@@ -71,4 +71,3 @@
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
 
-

--- a/test/expected/testWs/src/darwin/test_project_1/.cproject
+++ b/test/expected/testWs/src/darwin/test_project_1/.cproject
@@ -14,11 +14,11 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${{ProjName}}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326" name="Default" parent="org.eclipse.cdt.build.core.emptycfg">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326" name="Default" parent="org.eclipse.cdt.build.core.emptycfg">
 					<folderInfo id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326.1074977965" name="/" resourcePath="">
 						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.1749184169" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.1726019626" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder arguments="make VERBOSE=1" buildPath="{buildDir}" command="{buildDir}/build_env.sh" id="cdt.managedbuild.target.gnu.builder.macosx.base.390563205" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
+							<builder arguments="make VERBOSE=1" buildPath="testWs/build/test_project_1" command="testWs/build/test_project_1/build_env.sh" id="cdt.managedbuild.target.gnu.builder.macosx.base.390563205" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base"/>
 							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.108155396" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
 							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.985489660" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1629794530" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
@@ -38,12 +38,6 @@
 							</tool>
 						</toolChain>
 					</folderInfo>
-#ifndef IN_SOURCE
-					<sourceEntries>
-						<entry excluding="{name}_src" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="{name}_src"/>
-					</sourceEntries>
-#endif
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
@@ -61,11 +55,11 @@
 				</extensions>
 			</storageModule>
 			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-				<configuration artifactName="${{ProjName}}" buildProperties="" description="Run the tests" id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326.2127756105" name="Run Tests" parent="org.eclipse.cdt.build.core.emptycfg">
+				<configuration artifactName="${ProjName}" buildProperties="" description="Run the tests" id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326.2127756105" name="Run Tests" parent="org.eclipse.cdt.build.core.emptycfg">
 					<folderInfo id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326.2127756105." name="/" resourcePath="">
 						<toolChain id="cdt.managedbuild.toolchain.gnu.macosx.base.49520016" name="MacOSX GCC" superClass="cdt.managedbuild.toolchain.gnu.macosx.base">
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.MachO64" id="cdt.managedbuild.target.gnu.platform.macosx.base.394020843" name="Debug Platform" osList="macosx" superClass="cdt.managedbuild.target.gnu.platform.macosx.base"/>
-							<builder arguments="make run_tests" buildPath="{buildDir}" command="{buildDir}/build_env.sh" id="cdt.managedbuild.target.gnu.builder.macosx.base.1973106851" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base" incrementalBuildTarget="tests"/>
+							<builder arguments="make run_tests" buildPath="testWs/build/test_project_1" command="testWs/build/test_project_1/build_env.sh" id="cdt.managedbuild.target.gnu.builder.macosx.base.1973106851" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.macosx.base" incrementalBuildTarget="tests"/>
 							<tool id="cdt.managedbuild.tool.macosx.c.linker.macosx.base.1655895046" name="MacOS X C Linker" superClass="cdt.managedbuild.tool.macosx.c.linker.macosx.base"/>
 							<tool id="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base.1992604494" name="MacOS X C++ Linker" superClass="cdt.managedbuild.tool.macosx.cpp.linker.macosx.base">
 								<inputType id="cdt.managedbuild.tool.macosx.cpp.linker.input.1346160487" superClass="cdt.managedbuild.tool.macosx.cpp.linker.input">
@@ -91,15 +85,15 @@
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-		<project id="{name}.null.1248448670" name="{name}"/>
+		<project id="test_project_1.null.1248448670" name="test_project_1"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
 		<configuration configurationName="Default">
-			<resource resourceType="PROJECT" workspacePath="/{name}"/>
+			<resource resourceType="PROJECT" workspacePath="/test_project_1"/>
 		</configuration>
 		<configuration configurationName="Run Tests">
-			<resource resourceType="PROJECT" workspacePath="/{name}"/>
+			<resource resourceType="PROJECT" workspacePath="/test_project_1"/>
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="scannerConfiguration">
@@ -119,3 +113,4 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
+

--- a/test/expected/testWs/src/darwin/test_project_1/.project
+++ b/test/expected/testWs/src/darwin/test_project_1/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>{name}</name>
+	<name>test_project_1</name>
 	<comment></comment>
 	<projects>
 	</projects>
@@ -24,13 +24,5 @@
 		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
 		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
 	</natures>
-#ifndef IN_SOURCE
-	<linkedResources>
-		<link>
-			<name>{name}_src</name>
-			<type>2</type>
-			<location>{srcDir}</location>
-		</link>
-	</linkedResources>
-#endif
 </projectDescription>
+

--- a/test/expected/testWs/src/darwin/test_project_1/.settings/language_settings.xml
+++ b/test/expected/testWs/src/darwin/test_project_1/.settings/language_settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="(.*gcc)|(.*[gc]\+\+)|(.*clang)" prefer-non-shared="true"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" ref="shared-provider"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>
+

--- a/test/expected/testWs/src/linux2/test_project_1/.cproject
+++ b/test/expected/testWs/src/linux2/test_project_1/.cproject
@@ -18,7 +18,7 @@
 					<folderInfo id="cdt.managedbuild.toolchain.gnu.base.1726502031.1312995133" name="/" resourcePath="">
 						<toolChain id="cdt.managedbuild.toolchain.gnu.base.39642596" name="Linux GCC" superClass="cdt.managedbuild.toolchain.gnu.base">
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.target.gnu.platform.base.895951241" name="Debug Platform" osList="linux,hpux,aix,qnx" superClass="cdt.managedbuild.target.gnu.platform.base"/>
-							<builder arguments="make VERBOSE=1" buildPath="{buildDir}" command="{buildDir}/build_env.sh"  id="cdt.managedbuild.target.gnu.builder.base.2056731561" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.base"/>
+							<builder arguments="make VERBOSE=1" buildPath="testWs/build/test_project_1" command="testWs/build/test_project_1/build_env.sh"  id="cdt.managedbuild.target.gnu.builder.base.2056731561" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.target.gnu.builder.base"/>
 							<tool id="cdt.managedbuild.tool.gnu.archiver.base.1617669463" name="GCC Archiver" superClass="cdt.managedbuild.tool.gnu.archiver.base"/>
 							<tool id="cdt.managedbuild.tool.gnu.cpp.compiler.base.441413801" name="GCC C++ Compiler" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.base">
 								<option id="gnu.cpp.compiler.option.preprocessor.def.1443765429" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" valueType="definedSymbols">
@@ -41,24 +41,18 @@
 							</tool>
 						</toolChain>
 					</folderInfo>
-#ifndef IN_SOURCE
-					<sourceEntries>
-						<entry excluding="{name}_src" flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name=""/>
-						<entry flags="VALUE_WORKSPACE_PATH|RESOLVED" kind="sourcePath" name="{name}_src"/>
-					</sourceEntries>
-#endif
 				</configuration>
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
-		<project id="${{ProjName}}.null.608317806" name="${{ProjName}}"/>
+		<project id="${ProjName}.null.608317806" name="${ProjName}"/>
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
 	<storageModule moduleId="refreshScope" versionNumber="2">
 		<configuration configurationName="Default">
-			<resource resourceType="PROJECT" workspacePath="/${{ProjName}}"/>
+			<resource resourceType="PROJECT" workspacePath="/${ProjName}"/>
 		</configuration>
 	</storageModule>
 	<storageModule moduleId="scannerConfiguration">
@@ -72,3 +66,4 @@
 	</storageModule>
 	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 </cproject>
+

--- a/test/expected/testWs/src/linux2/test_project_1/.project
+++ b/test/expected/testWs/src/linux2/test_project_1/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>{name}</name>
+	<name>test_project_1</name>
 	<comment></comment>
 	<projects>
 	</projects>
@@ -24,13 +24,5 @@
 		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
 		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
 	</natures>
-#ifndef IN_SOURCE
-	<linkedResources>
-		<link>
-			<name>{name}_src</name>
-			<type>2</type>
-			<location>{srcDir}</location>
-		</link>
-	</linkedResources>
-#endif
 </projectDescription>
+

--- a/test/expected/testWs/src/linux2/test_project_1/.settings/language_settings.xml
+++ b/test/expected/testWs/src/linux2/test_project_1/.settings/language_settings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project>
+	<configuration id="cdt.managedbuild.toolchain.gnu.macosx.base.205247326" name="Default">
+		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
+			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
+			<provider-reference id="org.eclipse.cdt.core.ReferencedProjectsLanguageSettingsProvider" ref="shared-provider"/>
+			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="org.eclipse.cdt.managedbuilder.core.GCCBuildCommandParser" keep-relative-paths="false" name="CDT GCC Build Output Parser" parameter="(.*gcc)|(.*[gc]\+\+)|(.*clang)" prefer-non-shared="true"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.GCCBuiltinSpecsDetector" ref="shared-provider"/>
+			<provider-reference id="org.eclipse.cdt.managedbuilder.core.MBSLanguageSettingsProvider" ref="shared-provider"/>
+		</extension>
+	</configuration>
+</project>
+

--- a/test/testCPP.txt
+++ b/test/testCPP.txt
@@ -1,0 +1,7 @@
+#define TEST_DEF BLADEF
+BLA
+TEST_DEF
+#ifdef COND
+IfContent
+#endif
+END

--- a/test/unitTests.py
+++ b/test/unitTests.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+import unittest
+import StringIO
+
+import eclipsify_lib.generator as generator
+
+class GeneratorTest(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+
+    def runCppAndStrip(self, defs, useCpp):
+        return generator.applyCppAndStripComments('testCPP.txt', defs, useCpp)
+
+    def testGeneratorGenerate(self):
+        self.assertEqual(self.runCppAndStrip({ }, False), "BLA\nTEST_DEF\nIfContent\nEND\n")
+        self.assertEqual(self.runCppAndStrip({ }, True), "BLA\nBLADEF\nEND\n")
+        self.assertEqual(self.runCppAndStrip({ 'COND': 1 }, True), "BLA\nBLADEF\nIfContent\nEND\n")
+        self.assertEqual(self.runCppAndStrip({ 'BLA': 'NOT_BLA' }, True), "NOT_BLA\nBLADEF\nEND\n")
+        
+if __name__ == '__main__':
+    import rostest
+    rostest.rosrun('eclipsify', 'generator', GeneratorTest)


### PR DESCRIPTION
This finally solves the demand once discussed and agreed upon based on 01f64ce7c54 for (optional) in source placement of the configuration files (allowing for eclipse git integration). 

The price apart from additional complexity is a new surprising dependency : the c pre processor currently required to be in PATH as ```cpp```.
