### PR TITLE
Small adaptation to work with the most recent version of catkin_pkg.

### DIFF
--- a/src/eclipsify
+++ b/src/eclipsify
@@ -4,7 +4,7 @@ import catkin.workspace
 import exceptions
 
 try:
-    import catkin_pkg.packages
+    import catkin_pkg.package
     foundCatkinPkg = True
 except exceptions.ImportError:
     foundCatkinPkg = False
@@ -124,7 +124,7 @@ class PackageCollector:
     def processPackage(self, s):
         if options.verbose : print(colored("Testing package candidate '%s'." % s, 'yellow'));
         if isPackageSrc(s):
-            p = catkin_pkg.packages.parse_package(s);
+            p = catkin_pkg.package.parse_package(s);
             if options.verbose : print(colored("Is package named %s" % p.name, 'yellow'));
             if(p.name == package):
                 if self.cnt==0:
@@ -147,7 +147,7 @@ if foundCatkinPkg:
                 pkgCollector.processPackage(s)
             else:
                 if options.verbose : print(colored("Digging into source path '%s'." % s, 'yellow'));
-                for p in catkin_pkg.packages.find_packages(s):
+                for p in catkin_pkg.package.find_packages(s):
                     pkgCollector.processPackage(os.path.join(s, p))
     
     if pkgCollector.src:


### PR DESCRIPTION
Since PR https://github.com/ros-infrastructure/catkin_pkg/pull/171/files#diff-881522bb0a022aef976784a4d7855226 the import catkin_pkg.packages is not available anymore. 
@HannesSommer Could you check if this works for you?